### PR TITLE
Rename mini_al to miniaudio

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Lib           | Title
 [FNA-XNA/FAudio](https://github.com/FNA-XNA/FAudio) | FAudio - Accuracy-focused XAudio reimplementation for open platforms
 [soloud](https://github.com/jarikomppa/soloud) | Free, easy, portable audio engine for games
 [BareRose/atomix](https://github.com/BareRose/atomix) | Portable, single-file, wait-free atomic sound mixing library utilizing SSE-accelerated mixing
-[dr-soft/mini_al](https://github.com/dr-soft/mini_al) | Single file audio playback and capture library
+[dr-soft/miniaudio](https://github.com/dr-soft/miniaudio) | Single file audio playback and capture library
 
 ### Networking
 


### PR DESCRIPTION
mini_al was recently rebranded to miniaudio.