### PR TITLE
Update SDL on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Lib           | Title
 
 Lib           | Title
 ------------- | -------------
-[SDL](https://github.com/SDL-mirror/SDL) | Simple DirectMedia Layer
+[SDL](https://github.com/libsdl-org/SDL) | Simple DirectMedia Layer
 [SFML](https://github.com/SFML/SFML) | Simple and Fast Multimedia Library
 [glfw](https://github.com/glfw/glfw) | A multi-platform library
 [gainput](https://github.com/jkuhlmann/gainput) | C++ input library for games


### PR DESCRIPTION
The SDL link on README.md was archived, and it is now on a new repository. https://github.com/libsdl-org/SDL is the new while https://github.com/SDL-mirror/SDL is the old.